### PR TITLE
Don't use the %pylab magic; use the %matplotlib magic instead

### DIFF
--- a/intermediate/matplotlib/Plotting with matplotlib.ipynb
+++ b/intermediate/matplotlib/Plotting with matplotlib.ipynb
@@ -36,10 +36,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "# In the iPython Notebook and ipython you can alternatively use \"magic\" to import matplotlib and numpy\n",
-      "%pylab\n",
       "# if you want the plots to appear in the notebook\n",
-      "%pylab inline"
+      "%matplotlib inline"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Since the rest of the tutorial still uses import numpy, pylab, etc. there's no need to confuse things with the namespace population performed by `%pylab`

CC @philrosenfield 
